### PR TITLE
Eliminate redundant ref

### DIFF
--- a/lib.jsx
+++ b/lib.jsx
@@ -2,7 +2,7 @@ BlazeToReact = React.createClass({
   mixins: [ReactMeteorData],
   renderBlaze() {
     this.removeBlaze();
-    this.view = Blaze.renderWithData(Template[this.props.blazeTemplate], _.omit(this.props, 'blazeTemplate'), ReactDOM.findDOMNode(this.refs[this.props.blazeTemplate]));
+    this.view = Blaze.renderWithData(Template[this.props.blazeTemplate], _.omit(this.props, 'blazeTemplate'), ReactDOM.findDOMNode(this));
   },
   removeBlaze() {
     if (this.view) Blaze.remove(this.view);
@@ -19,6 +19,6 @@ BlazeToReact = React.createClass({
     this.removeBlaze();
   },
   render() {
-    return <div ref={this.props.blazeTemplate}/>
+    return <div />
   }
 });


### PR DESCRIPTION
I'm hitting a stage at which this ref isn't yet present, even during `componentDidMount`, and getting an error so I'm trying this... but it really seems like the ref shouldn't be necessary at all, and hey, why not simplify? We'll see how it goes...
