### PR TITLE
Fix lack of re-render when used with a ternary operator

### DIFF
--- a/lib.jsx
+++ b/lib.jsx
@@ -12,6 +12,10 @@ BlazeToReact = React.createClass({
     this.renderBlaze();
     return this.props;
   },
+  componentDidUpdate() {
+    // Needed when used with a conditional show, like {condition ? <BlazeToCreact ../> : null}
+    this.renderBlaze();
+  },
   componentDidMount() {
     this.renderBlaze();
   },


### PR DESCRIPTION
`{condition ? <BlazeToCreact ../> : null}`

When `condition` is toggled, blaze is not re-rendered currently.
