### PR TITLE
Meteor 1.3 support (react from npm, export default BlazeToReact)

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,0 +1,7 @@
+# meteor-blaze-to-react
+
+## vNEXT
+
+## v1.0.0
+
+* Meteor 1.3 style, using `react` from npm and exporting a default BlazeToReact.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ Installation
 meteor add gwendall:blaze-to-react
 ```
 
+Note:
+
+* For Meteor 1.2, use the latest 0.x.x release.  It relies on the `react`
+package.
+
+* For Meteor 1.3+, use the latest 1.x.x release.  It relies on react from npm.
+`<BlazeToReact>` is still provided as a global for convenience.  But if you
+want, you can `import BlazeToReact from 'meteor/gwendall:blaze-to-react';`
+
 How it works
 -----------
 

--- a/lib.jsx
+++ b/lib.jsx
@@ -1,3 +1,6 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
 BlazeToReact = React.createClass({
   mixins: [ReactMeteorData],
   renderBlaze() {
@@ -22,3 +25,5 @@ BlazeToReact = React.createClass({
     return <div ref={this.props.blazeTemplate}/>
   }
 });
+
+export default BlazeToReact;

--- a/package.js
+++ b/package.js
@@ -2,16 +2,12 @@ Package.describe({
   name: 'gwendall:blaze-to-react',
   summary: 'Turn any Blaze template into a React component',
   git: 'https://github.com/gwendall/meteor-blaze-to-react.git',
-  version: '0.1.2'
+  version: '1.0.0'
 });
 
 Package.onUse(function(api, where) {
-  api.versionsFrom('1.2');
-  api.use([
-    'react@0.14.1_1',
-    'templating@1.1.5', 
-    'underscore@1.0.4'
-  ]);
-  api.addFiles('lib.jsx');
+  api.versionsFrom('1.3-rc.0');
+  api.use([ 'ecmascript', 'templating', 'underscore', 'react-meteor-data' ]);
+  api.mainModule('lib.jsx', 'client');
   api.export('BlazeToReact');
 });


### PR DESCRIPTION
Hey, since Meteor 1.3 is scheduled for [March 21st](https://github.com/meteor/meteor/issues/6266#issuecomment-196945961) I thought it would be nice to update this very useful package.

I bumped the major version to v1, since this would be an (unavoidable) breaking change.
