### PR TITLE
Fixed renderBlaze() bug

### DIFF
--- a/lib.jsx
+++ b/lib.jsx
@@ -12,7 +12,10 @@ BlazeToReact = React.createClass({
   },
   getMeteorData() {
     // Ensure a re-rendering of the template if a prop changes
-    this.renderBlaze();
+    
+    if (this._isMounted) {
+      this.renderBlaze();
+    }
     return this.props;
   },
   componentDidUpdate() {
@@ -20,9 +23,11 @@ BlazeToReact = React.createClass({
     this.renderBlaze();
   },
   componentDidMount() {
+    this._isMounted = true;
     this.renderBlaze();
   },
   componentWillUnmount() {
+    this._isMounted = false;
     this.removeBlaze();
   },
   render() {


### PR DESCRIPTION
It seems renderBlaze() would get called before the mount happens, which gives a
warning that parent node is not defined. To fix this, I added an _isMounted
property per the devs recommendations rather than using isMounted().
https://facebook.github.io/react/blog/2015/12/16/ismounted-antipattern.html
